### PR TITLE
Add CLI menu for easier navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ entrada y comandos adicionales para un uso más profesional.
 * `gemini-web.js` – Alias que inicia el servidor web. Arranca el
   servidor de la carpeta `webui` al ejecutar `node gemini-web.js`.
 
+* `g4f-menu.js` – Presenta un pequeño menú en la terminal para
+  escoger entre iniciar la CLI, la interfaz web o las utilidades de
+  `xdtest`.
+
 * `gemini-cli/` – Carpeta residual del proyecto original de Gemini
   CLI. Ya no se utiliza y se conserva únicamente como referencia.
 
@@ -64,6 +68,13 @@ abusos (10.000 caracteres). Cambie de modo con `/mode chat` o
 Si no se especifica otro valor, el proveedor por defecto para las
 peticiones de IA es **g4f**, que selecciona automáticamente un backend
 disponible.
+
+### Menú interactivo
+
+Ejecute `node g4f-menu.js` para mostrar un menú que permite lanzar la
+CLI, la interfaz web o la utilidad `cyrah`. Si instala el paquete de
+forma global, podrá invocar simplemente `g4f-menu` desde cualquier
+directorio.
 
 ## Eliminación de referencias a Gemini
 

--- a/g4f-menu.js
+++ b/g4f-menu.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/*
+ * Menú interactivo para lanzar distintas herramientas del proyecto.
+ * Permite elegir entre la CLI, la interfaz web o las utilidades de
+ * "xdtest" (Cyrah). Tras finalizar cada herramienta, vuelve al menú.
+ */
+
+const readline = require('readline');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const options = [
+  { label: 'Abrir CLI', script: 'g4f-cli.js' },
+  { label: 'Abrir interfaz web', script: 'gemini-web.js' },
+  { label: 'Ejecutar Cyrah', script: path.join('xdtest', 'dist', 'bin', 'cyrah.js') },
+  { label: 'Salir', script: null }
+];
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+function showMenu() {
+  console.log('\nSeleccione una opción:\n');
+  options.forEach((opt, i) => console.log(`  ${i + 1}. ${opt.label}`));
+  rl.question('> ', (answer) => {
+    const index = parseInt(answer, 10) - 1;
+    runOption(index);
+  });
+}
+
+function runOption(index) {
+  const opt = options[index];
+  if (!opt) {
+    console.log('Opción inválida.');
+    return showMenu();
+  }
+  if (!opt.script) {
+    console.log('Hasta luego.');
+    rl.close();
+    return;
+  }
+  rl.pause();
+  const scriptPath = path.join(__dirname, opt.script);
+  const child = spawn('node', [scriptPath], { stdio: 'inherit' });
+  child.on('exit', () => {
+    rl.resume();
+    showMenu();
+  });
+}
+
+console.log('Menú principal de g4f');
+showMenu();
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "g4f-cli": "g4f-cli.js",
     "gemini-cli": "gemini-cli.js",
     "gemini-web": "gemini-web.js",
+    "g4f-menu": "g4f-menu.js",
     "cyrah": "xdtest/dist/bin/cyrah.js",
     "cyrah-auto": "xdtest/dist/bin/cyrah-auto.js"
   },


### PR DESCRIPTION
## Summary
- add a small interactive menu script
- register `g4f-menu` command in package.json
- document the new menu option in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888e00375a48328b3bb679dcb014cb8