### PR TITLE
Fix missing cyrah binary after install

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ instalar este paquete de forma global (`npm install -g .`) estarán
 disponibles los binarios `cyrah` y `cyrah-auto` junto al resto de
 herramientas. Puede ejecutarlos de la siguiente manera:
 
+Antes de usar `cyrah` por primera vez asegúrese de compilar los
+archivos TypeScript:
+
+```sh
+npm --workspace=xdtest run build
+```
+
 ```sh
 cyrah --help
 cyrah-auto

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "start": "node g4f-cli.js",
     "web": "node gemini-web.js",
-    "test": "echo \"No tests specified\""
+    "test": "echo \"No tests specified\"",
+    "prepare": "npm --workspace=xdtest run build"
   },
   "workspaces": ["xdtest"],
   "keywords": ["g4f", "cli", "web"],


### PR DESCRIPTION
## Summary
- run `npm --workspace=xdtest run build` automatically when installing
- document the build step for Cyrah in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888e20bd520832385b619152241f9e4