### PR TITLE
Set g4f provider to auto

### DIFF
--- a/g4f-cli.js
+++ b/g4f-cli.js
@@ -67,7 +67,10 @@ const commandHistory = [];
  */
 async function callG4F(prompt) {
   const messages = [{ role: 'user', content: prompt }];
-  const text = await g4f.chatCompletion(messages, { model: currentModel });
+  const text = await g4f.chatCompletion(messages, {
+    model: currentModel,
+    provider: g4f.providers.any,
+  });
   return text || '';
 }
 

--- a/webui/server.js
+++ b/webui/server.js
@@ -70,7 +70,7 @@ const server = http.createServer((req, res) => {
         try {
           const text = await g4f.chatCompletion(
             [{ role: 'user', content: message }],
-            { model }
+            { model, provider: g4f.providers.any }
           );
           if (text) {
             const json = JSON.stringify({ response: text });


### PR DESCRIPTION
## Summary
- use `g4f.providers.any` when calling `g4f.chatCompletion`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888ec7ee82c83239788298ea139c401