### PR TITLE
Fix gemini-cli global path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.tgz

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Ejecute `node gemini-cli.js` (o `node g4f-cli.js`) en la raíz del
 proyecto. Si instala el paquete de forma global (`npm install -g .`)
 podrá invocar simplemente `g4f-cli` o `gemini-web` desde cualquier
 directorio.
+Si al ejecutar `gemini-cli` en Windows aparece un mensaje "Cannot find module", instale el proyecto con `npm install -g .` y asegurese de que la carpeta global de npm este en la variable PATH. Como alternativa, ejecute la herramienta con `node %AppData%\npm\node_modules\g4f-unified-interface\gemini-cli.js`.
 Por defecto
 comenzará en modo `cli`. Escriba `/help` para ver los comandos
 disponibles. El tamaño máximo de entrada está limitado a evitar

--- a/gemini-cli.js
+++ b/gemini-cli.js
@@ -6,4 +6,6 @@
  * directorio.
  */
 
-require('./g4f-cli.js');
+const path = require('path');
+const cliPath = path.join(__dirname, 'g4f-cli.js');
+require(cliPath);

--- a/gemini-web.js
+++ b/gemini-web.js
@@ -6,4 +6,6 @@
  * adicional, edite el archivo webui/server.js directamente.
  */
 
-require('./webui/server.js');
+const path = require('path');
+const serverPath = path.join(__dirname, 'webui', 'server.js');
+require(serverPath);


### PR DESCRIPTION
## Summary
- fix path resolution for gemini-cli and gemini-web
- document Windows install instructions
- ignore node_modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888f0d3ef088323825f3bd7fe4bbe6d