### PR TITLE
Improve configuration via dotenv

### DIFF
--- a/g4f-cli.js
+++ b/g4f-cli.js
@@ -22,6 +22,7 @@ const { exec } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const { G4F } = require('g4f');
+require('dotenv').config();
 const pkg = require('./package.json');
 const VERSION = pkg.version || 'dev';
 
@@ -39,7 +40,7 @@ const MODELS = ['gpt-4.1', 'gpt-3.5-turbo', 'gpt-4', 'claude-3-opus'];
 
 // Current model selected by the user. Defaults to the first
 // available model.
-let currentModel = MODELS[0];
+let currentModel = process.env.DEFAULT_MODEL && MODELS.includes(process.env.DEFAULT_MODEL) ? process.env.DEFAULT_MODEL : MODELS[0];
 
 // Track the current mode: 'cli', 'chat' or 'interpreter'. Defaults
 // to 'cli'.

--- a/webui/server.js
+++ b/webui/server.js
@@ -2,10 +2,12 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const { G4F } = require('g4f');
+require('dotenv').config();
 
 // Reusable g4f client
 const g4f = new G4F();
 
+const DEFAULT_MODEL = process.env.DEFAULT_MODEL || "gpt-4.1";
 // SPDX-License-Identifier: Apache-2.0
 
 const publicDir = path.join(__dirname, 'public');
@@ -66,7 +68,7 @@ const server = http.createServer((req, res) => {
       try {
         const parsed = JSON.parse(body || '{}');
         const message = typeof parsed.message === 'string' ? parsed.message : '';
-        const model = typeof parsed.model === 'string' ? parsed.model : 'gpt-4.1';
+        const model = typeof parsed.model === 'string' ? parsed.model : DEFAULT_MODEL;
         try {
           const text = await g4f.chatCompletion(
             [{ role: 'user', content: message }],


### PR DESCRIPTION
## Summary
- load environment variables using dotenv
- allow DEFAULT_MODEL env to set initial g4f model
- apply same default model mechanism on the server
- build and run tests

## Testing
- `npm test`
- `npm run build`
- `npm --workspace=xdtest test`

------
https://chatgpt.com/codex/tasks/task_b_6888fe4c43a48323887c742b8fe59222