### PR TITLE
fix: improve menu execution and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ entrada y comandos adicionales para un uso más profesional.
 
 ## Uso
 
+> **Nota:** Para ejecutar los scripts definidos en `package.json` utilice
+> siempre `npm run <script>`. Ejecutar `npm <script>` sin la palabra
+> `run` provocará el mensaje de error `npm ERR! could not determine
+> executable to run`.
+
 ### Web UI
 
 1. Instale las dependencias (incluida `g4f`) con `npm install`.

--- a/g4f-menu.js
+++ b/g4f-menu.js
@@ -9,6 +9,12 @@ const readline = require('readline');
 const { spawn } = require('child_process');
 const path = require('path');
 
+// Use the current Node.js executable to avoid relying on `node`
+// being present in the PATH. This improves compatibility across
+// environments where the command might not be directly accessible
+// (e.g. installations via nvm or custom setups).
+const NODE_PATH = process.execPath;
+
 const options = [
   { label: 'Abrir CLI', script: 'g4f-cli.js' },
   { label: 'Abrir interfaz web', script: 'gemini-web.js' },
@@ -43,8 +49,18 @@ function runOption(index) {
   }
   rl.pause();
   const scriptPath = path.join(__dirname, opt.script);
-  const child = spawn('node', [scriptPath], { stdio: 'inherit' });
+  const child = spawn(NODE_PATH, [scriptPath], { stdio: 'inherit' });
+
+  // When the spawned process finishes, resume the menu.
   child.on('exit', () => {
+    rl.resume();
+    showMenu();
+  });
+
+  // If the child process could not be executed, inform the user and
+  // return to the menu instead of crashing.
+  child.on('error', (err) => {
+    console.error(`No se pudo ejecutar ${scriptPath}:`, err.message);
     rl.resume();
     showMenu();
   });


### PR DESCRIPTION
## Summary
- launch menu items using the current Node executable instead of relying on `node` in PATH
- add error handling when launching menu options
- document the need to run npm scripts via `npm run` to avoid execution errors

## Testing
- `npm test`
- `node g4f-menu.js <<'EOF'
4
EOF`


------
https://chatgpt.com/codex/tasks/task_b_689b5650ef98832aaf5304df61523d58