### PR TITLE
feat(cli): notify on unknown slash command

### DIFF
--- a/g4f-cli
+++ b/g4f-cli
@@ -283,7 +283,9 @@ async function handleSlashCommand(line) {
       return true;
     }
     default:
-      return false;
+      // Inform the user when a slash command is not recognised
+      console.log('Comando no reconocido. Escribe /help para la ayuda.');
+      return true;
   }
 }
 


### PR DESCRIPTION
## Summary
- Display explicit message when a slash command is not recognised and avoid forwarding it to the AI/shell

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b69c57a90832ab704b7ad2b796173